### PR TITLE
Handle yfinance intraday lookback limits

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,16 +1,154 @@
-# This is a sample Python script.
+"""IntelliJ-friendly entry point for the LSTM intraday predictor workflow."""
+from __future__ import annotations
 
-# Press Shift+F10 to execute it or replace it with your code.
-# Press Double Shift to search everywhere for classes, files, tool windows, actions, and settings.
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Optional
+
+import pandas as pd
+
+from src.data.data_loader import YFinanceConfig, YFinanceLoader
+from src.pipeline.dataset import SequenceConfig
+from src.pipeline.predictor import LSTMPredictor
+from src.pipeline.trainer import ArtifactPaths, LSTMTrainer, TrainerConfig
+
+ARTIFACT_DIR = Path("artifacts")
+MODEL_PATH = ARTIFACT_DIR / "bidirectional_lstm.pth"
+FEATURE_SCALER_PATH = ARTIFACT_DIR / "feature_scaler.pkl"
+TARGET_SCALER_PATH = ARTIFACT_DIR / "target_scaler.pkl"
+TRAINING_STATE_PATH = ARTIFACT_DIR / "training_state.json"
 
 
-def print_hi(name):
-    # Use a breakpoint in the code line below to debug your script.
-    print(f'Hi, {name}')  # Press Ctrl+F8 to toggle the breakpoint.
+@dataclass
+class WorkflowConfig:
+    """Configuration block consumed by the IntelliJ run configuration."""
+
+    ticker: str = "AAPL"
+    interval: str = "15m"
+    lookback_days: int = 60
+    lookback_window: int = 200
+    horizon: int = 10
+    epochs: int = 30
+    batch_size: int = 32
+    learning_rate: float = 1e-3
+    force_retrain: bool = False
 
 
-# Press the green button in the gutter to run the script.
-if __name__ == '__main__':
-    print_hi('PyCharm')
+class IntradayWorkflow:
+    """Coordinates daily training and rolling inference for IDE usage."""
 
-# See PyCharm help at https://www.jetbrains.com/help/pycharm/
+    def __init__(self, config: WorkflowConfig) -> None:
+        self.config = config
+        ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
+
+    def run_daily_training(self) -> Optional[Dict[str, float]]:
+        """Train the LSTM if the saved weights are missing or stale."""
+
+        if not self.config.force_retrain and not self._is_training_needed():
+            return None
+
+        loader = YFinanceLoader(
+            YFinanceConfig(
+                ticker=self.config.ticker,
+                interval=self.config.interval,
+                lookback_days=self.config.lookback_days,
+            )
+        )
+        data = loader.load()
+        sequence_config = SequenceConfig(
+            lookback=self.config.lookback_window, horizon=self.config.horizon
+        )
+        trainer_config = TrainerConfig(
+            epochs=self.config.epochs,
+            batch_size=self.config.batch_size,
+            learning_rate=self.config.learning_rate,
+        )
+        artifact_paths = ArtifactPaths(MODEL_PATH, FEATURE_SCALER_PATH, TARGET_SCALER_PATH)
+
+        trainer = LSTMTrainer(sequence_config, trainer_config, artifact_paths)
+        metrics = trainer.train(data)
+        self._write_training_state()
+        return metrics
+
+    def generate_predictions(self) -> pd.DataFrame:
+        """Load the latest data and produce the next horizon of close prices."""
+
+        if not MODEL_PATH.exists():
+            raise FileNotFoundError(
+                "Model weights not found. Run run_daily_training() before requesting predictions."
+            )
+
+        loader = YFinanceLoader(
+            YFinanceConfig(
+                ticker=self.config.ticker,
+                interval=self.config.interval,
+                lookback_days=self.config.lookback_days,
+            )
+        )
+        data = loader.load()
+        sequence_config = SequenceConfig(
+            lookback=self.config.lookback_window, horizon=self.config.horizon
+        )
+        predictor = LSTMPredictor(
+            sequence_config,
+            MODEL_PATH,
+            FEATURE_SCALER_PATH,
+            TARGET_SCALER_PATH,
+        )
+        predictions = predictor.predict(data)
+        prediction_index = pd.date_range(
+            start=data.index[-1], periods=self.config.horizon + 1, freq=self.config.interval
+        )[1:]
+        return pd.DataFrame({"predicted_close": predictions}, index=prediction_index)
+
+    def _is_training_needed(self) -> bool:
+        if not MODEL_PATH.exists():
+            return True
+        state = self._read_training_state()
+        if state is None:
+            return True
+        last_trained_str = state.get("last_trained")
+        if not last_trained_str:
+            return True
+        last_trained = datetime.fromisoformat(last_trained_str)
+        now = datetime.now(timezone.utc)
+        return last_trained.date() < now.date()
+
+    def _read_training_state(self) -> Optional[Dict[str, str]]:
+        if not TRAINING_STATE_PATH.exists():
+            return None
+        try:
+            return json.loads(TRAINING_STATE_PATH.read_text())
+        except json.JSONDecodeError:
+            return None
+
+    def _write_training_state(self) -> None:
+        state = {"last_trained": datetime.now(timezone.utc).isoformat()}
+        TRAINING_STATE_PATH.write_text(json.dumps(state, indent=2))
+
+
+def print_metrics(metrics: Dict[str, float]) -> None:
+    for key, value in metrics.items():
+        if key == "directional_accuracy":
+            print(f"{key}: {value:.2f}%")
+        else:
+            print(f"{key}: {value:.6f}")
+
+
+def run() -> None:
+    """Entry point used by IntelliJ's Run Configuration."""
+
+    workflow = IntradayWorkflow(WorkflowConfig())
+    metrics = workflow.run_daily_training()
+    if metrics:
+        print("Training completed. Evaluation metrics on hold-out set:")
+        print_metrics(metrics)
+    predictions = workflow.generate_predictions()
+    print("Next interval predictions:")
+    print(predictions)
+
+
+if __name__ == "__main__":
+    run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+yfinance
+pandas
+numpy
+scikit-learn
+torch
+joblib

--- a/src/data/data_loader.py
+++ b/src/data/data_loader.py
@@ -1,0 +1,57 @@
+"""Data loading utilities for fetching historical OHLC data."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+import pandas as pd
+import yfinance as yf
+
+
+@dataclass
+class YFinanceConfig:
+    ticker: str
+    interval: str = "15m"
+    lookback_days: int = 60
+
+    def resolve_start_end(self) -> tuple[datetime, datetime]:
+        end = datetime.utcnow()
+        start = end - timedelta(days=self.lookback_days)
+        return start, end
+
+
+class YFinanceLoader:
+    """Wrapper around ``yfinance`` for fetching OHLCV data."""
+
+    def __init__(self, config: YFinanceConfig) -> None:
+        self.config = config
+
+    def load(self) -> pd.DataFrame:
+        start, end = self.config.resolve_start_end()
+        data = yf.download(
+            tickers=self.config.ticker,
+            interval=self.config.interval,
+            start=start,
+            end=end,
+            auto_adjust=False,
+            progress=False,
+        )
+        if data.empty:
+            raise ValueError(
+                f"No data returned from yfinance for ticker {self.config.ticker}"
+            )
+        data = data.rename(
+            columns={
+                "Open": "open",
+                "High": "high",
+                "Low": "low",
+                "Close": "close",
+                "Adj Close": "adj_close",
+                "Volume": "volume",
+            }
+        )
+        data.index = pd.to_datetime(data.index)
+        data.sort_index(inplace=True)
+        return data
+
+
+__all__ = ["YFinanceConfig", "YFinanceLoader"]

--- a/src/data/data_loader.py
+++ b/src/data/data_loader.py
@@ -1,0 +1,83 @@
+"""Data loading utilities for fetching historical OHLC data."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import pandas as pd
+import yfinance as yf
+from yfinance.shared import _ERRORS
+
+
+YFPricesMissingError = _ERRORS.get("YFPricesMissingError", Exception)
+
+INTRADAY_MAX_LOOKBACK = {
+    "15m": 59,
+}
+
+
+@dataclass
+class YFinanceConfig:
+    ticker: str
+    interval: str = "15m"
+    lookback_days: int = 60
+
+    def resolve_period(self) -> str:
+        return f"{self.lookback_days}d"
+
+    def resolved_lookback_days(self) -> int:
+        max_days = INTRADAY_MAX_LOOKBACK.get(self.interval)
+        if max_days is None:
+            return self.lookback_days
+        return min(self.lookback_days, max_days)
+
+    def build_download_kwargs(self) -> dict:
+        lookback_days = self.resolved_lookback_days()
+        if lookback_days != self.lookback_days:
+            period = f"{lookback_days}d"
+        else:
+            period = self.resolve_period()
+        return {
+            "tickers": self.ticker,
+            "interval": self.interval,
+            "period": period,
+            "auto_adjust": False,
+            "progress": False,
+        }
+
+
+class YFinanceLoader:
+    """Wrapper around ``yfinance`` for fetching OHLCV data."""
+
+    def __init__(self, config: YFinanceConfig) -> None:
+        self.config = config
+
+    def load(self) -> pd.DataFrame:
+        kwargs = self.config.build_download_kwargs()
+        try:
+            data = yf.download(**kwargs)
+        except YFPricesMissingError:
+            max_days = INTRADAY_MAX_LOOKBACK.get(self.config.interval)
+            if max_days is None or kwargs["period"] == f"{max_days}d":
+                raise
+            data = yf.download(
+                **kwargs | {"period": f"{max_days}d"}
+            )
+        if data.empty:
+            raise ValueError(
+                f"No data returned from yfinance for ticker {self.config.ticker}"
+            )
+        data = data.rename(
+            columns={
+                "Open": "open",
+                "High": "high",
+                "Low": "low",
+                "Close": "close",
+                "Adj Close": "adj_close",
+                "Volume": "volume",
+            }
+        )
+        data.index = pd.to_datetime(data.index)
+        data.sort_index(inplace=True)
+        return data
+
+
+__all__ = ["YFinanceConfig", "YFinanceLoader"]

--- a/src/features/feature_engineering.py
+++ b/src/features/feature_engineering.py
@@ -1,0 +1,37 @@
+"""Feature engineering utilities for technical indicators."""
+from __future__ import annotations
+
+import pandas as pd
+
+
+def compute_rsi(series: pd.Series, period: int = 14) -> pd.Series:
+    delta = series.diff()
+    up = delta.clip(lower=0)
+    down = -delta.clip(upper=0)
+    roll_up = up.ewm(span=period, adjust=False).mean()
+    roll_down = down.ewm(span=period, adjust=False).mean()
+    rs = roll_up / (roll_down + 1e-9)
+    rsi = 100 - (100 / (1 + rs))
+    return rsi
+
+
+def add_technical_features(df: pd.DataFrame) -> pd.DataFrame:
+    features = df.copy()
+    close = features["close"]
+
+    features["ema_20"] = close.ewm(span=20, adjust=False).mean()
+    features["ema_50"] = close.ewm(span=50, adjust=False).mean()
+
+    ema_12 = close.ewm(span=12, adjust=False).mean()
+    ema_26 = close.ewm(span=26, adjust=False).mean()
+    features["macd"] = ema_12 - ema_26
+    features["macd_signal"] = features["macd"].ewm(span=9, adjust=False).mean()
+
+    features["rsi"] = compute_rsi(close, period=14)
+    features["return_change"] = close.pct_change().fillna(0)
+
+    features = features.dropna()
+    return features
+
+
+__all__ = ["add_technical_features"]

--- a/src/models/lstm_model.py
+++ b/src/models/lstm_model.py
@@ -1,0 +1,43 @@
+"""Neural network models for time-series forecasting."""
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+
+class BidirectionalLSTM(nn.Module):
+    """Three-layer bidirectional LSTM for multi-step forecasting."""
+
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int = 128,
+        num_layers: int = 3,
+        dropout: float = 0.2,
+        output_size: int = 10,
+    ) -> None:
+        super().__init__()
+        self.lstm = nn.LSTM(
+            input_size=input_size,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+            dropout=dropout,
+            bidirectional=True,
+            batch_first=True,
+        )
+        self.fc = nn.Sequential(
+            nn.Linear(hidden_size * 2, hidden_size),
+            nn.ReLU(),
+            nn.Dropout(dropout),
+            nn.Linear(hidden_size, output_size),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        lstm_out, _ = self.lstm(x)
+        # Use last time step from both directions
+        last_timestep = lstm_out[:, -1, :]
+        out = self.fc(last_timestep)
+        return out
+
+
+__all__ = ["BidirectionalLSTM"]

--- a/src/pipeline/dataset.py
+++ b/src/pipeline/dataset.py
@@ -1,0 +1,50 @@
+"""Utilities for preparing time-series sequences."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+
+
+@dataclass
+class SequenceConfig:
+    lookback: int = 200
+    horizon: int = 10
+
+
+class SequenceDataset(Dataset):
+    def __init__(self, features: np.ndarray, targets: np.ndarray) -> None:
+        if len(features) != len(targets):
+            raise ValueError("Features and targets must have the same length")
+        self.features = torch.tensor(features, dtype=torch.float32)
+        self.targets = torch.tensor(targets, dtype=torch.float32)
+
+    def __len__(self) -> int:  # type: ignore[override]
+        return len(self.features)
+
+    def __getitem__(self, idx: int) -> Tuple[torch.Tensor, torch.Tensor]:  # type: ignore[override]
+        return self.features[idx], self.targets[idx]
+
+
+def build_sequences(
+    values: np.ndarray,
+    target: np.ndarray,
+    config: SequenceConfig,
+) -> tuple[np.ndarray, np.ndarray]:
+    lookback = config.lookback
+    horizon = config.horizon
+    features = []
+    targets = []
+    for end_idx in range(lookback, len(values) - horizon + 1):
+        start_idx = end_idx - lookback
+        feature_window = values[start_idx:end_idx]
+        target_window = target[end_idx : end_idx + horizon]
+        features.append(feature_window)
+        targets.append(target_window)
+    return np.array(features), np.array(targets)
+
+
+__all__ = ["SequenceDataset", "SequenceConfig", "build_sequences"]

--- a/src/pipeline/predictor.py
+++ b/src/pipeline/predictor.py
@@ -1,0 +1,77 @@
+"""Inference utilities for the trained LSTM model."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import joblib
+import numpy as np
+import torch
+
+from src.features.feature_engineering import add_technical_features
+from src.models.lstm_model import BidirectionalLSTM
+from src.pipeline.dataset import SequenceConfig
+
+
+@dataclass
+class PredictorConfig:
+    device: str = "cuda" if torch.cuda.is_available() else "cpu"
+
+
+class LSTMPredictor:
+    def __init__(
+        self,
+        sequence_config: SequenceConfig,
+        model_path,
+        feature_scaler_path,
+        target_scaler_path,
+        predictor_config: PredictorConfig | None = None,
+    ) -> None:
+        self.sequence_config = sequence_config
+        self.device = (predictor_config or PredictorConfig()).device
+
+        self.feature_scaler = joblib.load(feature_scaler_path)
+        self.target_scaler = joblib.load(target_scaler_path)
+
+        input_size = self.feature_scaler.mean_.shape[0]
+        self.model = BidirectionalLSTM(
+            input_size=input_size,
+            output_size=sequence_config.horizon,
+        )
+        state_dict = torch.load(model_path, map_location=self.device)
+        self.model.load_state_dict(state_dict)
+        self.model.to(self.device)
+        self.model.eval()
+
+        self.feature_columns = [
+            "open",
+            "high",
+            "low",
+            "close",
+            "ema_20",
+            "ema_50",
+            "macd",
+            "rsi",
+            "return_change",
+        ]
+
+    def predict(self, raw_df) -> np.ndarray:
+        df = add_technical_features(raw_df)
+        if len(df) < self.sequence_config.lookback:
+            raise ValueError(
+                "Insufficient data for prediction. Increase history length or reduce lookback."
+            )
+        features = df[self.feature_columns]
+        scaled_features = self.feature_scaler.transform(features.values)
+
+        latest_features = scaled_features[-self.sequence_config.lookback :]
+        input_tensor = torch.tensor(
+            latest_features[np.newaxis, :, :], dtype=torch.float32, device=self.device
+        )
+
+        with torch.no_grad():
+            scaled_prediction = self.model(input_tensor).cpu().numpy()
+
+        prediction = self.target_scaler.inverse_transform(scaled_prediction)
+        return prediction.flatten()
+
+
+__all__ = ["LSTMPredictor", "PredictorConfig"]

--- a/src/pipeline/trainer.py
+++ b/src/pipeline/trainer.py
@@ -1,0 +1,177 @@
+"""Training and evaluation pipeline for the LSTM model."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Tuple
+
+import joblib
+import numpy as np
+import torch
+from sklearn.metrics import mean_absolute_error, mean_squared_error
+from sklearn.preprocessing import StandardScaler
+from torch.utils.data import DataLoader
+
+from src.features.feature_engineering import add_technical_features
+from src.models.lstm_model import BidirectionalLSTM
+from src.pipeline.dataset import SequenceConfig, SequenceDataset, build_sequences
+
+
+@dataclass
+class TrainerConfig:
+    epochs: int = 30
+    batch_size: int = 32
+    learning_rate: float = 1e-3
+    device: str = "cuda" if torch.cuda.is_available() else "cpu"
+
+
+@dataclass
+class ArtifactPaths:
+    model_path: Path
+    feature_scaler_path: Path
+    target_scaler_path: Path
+
+
+class LSTMTrainer:
+    def __init__(
+        self,
+        sequence_config: SequenceConfig,
+        trainer_config: TrainerConfig,
+        artifact_paths: ArtifactPaths,
+    ) -> None:
+        self.sequence_config = sequence_config
+        self.trainer_config = trainer_config
+        self.artifact_paths = artifact_paths
+
+    def _prepare_sequences(
+        self, data: np.ndarray, target: np.ndarray
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        return build_sequences(data, target, self.sequence_config)
+
+    def _split_dataset(
+        self, features: np.ndarray, targets: np.ndarray, split_ratio: float = 0.8
+    ) -> Tuple[SequenceDataset, SequenceDataset]:
+        split_index = int(len(features) * split_ratio)
+        train_dataset = SequenceDataset(features[:split_index], targets[:split_index])
+        test_dataset = SequenceDataset(features[split_index:], targets[split_index:])
+        return train_dataset, test_dataset
+
+    def _create_dataloaders(
+        self, train_dataset: SequenceDataset, test_dataset: SequenceDataset
+    ) -> Tuple[DataLoader, DataLoader]:
+        train_loader = DataLoader(
+            train_dataset,
+            batch_size=self.trainer_config.batch_size,
+            shuffle=True,
+            drop_last=False,
+        )
+        test_loader = DataLoader(
+            test_dataset,
+            batch_size=self.trainer_config.batch_size,
+            shuffle=False,
+            drop_last=False,
+        )
+        return train_loader, test_loader
+
+    def train(self, raw_df) -> Dict[str, float]:
+        df = add_technical_features(raw_df)
+        feature_columns = [
+            "open",
+            "high",
+            "low",
+            "close",
+            "ema_20",
+            "ema_50",
+            "macd",
+            "rsi",
+            "return_change",
+        ]
+        features = df[feature_columns]
+        target = df[["close"]]
+
+        feature_scaler = StandardScaler()
+        target_scaler = StandardScaler()
+        scaled_features = feature_scaler.fit_transform(features.values)
+        scaled_target = target_scaler.fit_transform(target.values).squeeze()
+
+        sequences, targets = self._prepare_sequences(scaled_features, scaled_target)
+        train_dataset, test_dataset = self._split_dataset(sequences, targets)
+        train_loader, test_loader = self._create_dataloaders(train_dataset, test_dataset)
+
+        model = BidirectionalLSTM(
+            input_size=sequences.shape[-1],
+            output_size=self.sequence_config.horizon,
+        ).to(self.trainer_config.device)
+
+        criterion = torch.nn.MSELoss()
+        optimizer = torch.optim.Adam(model.parameters(), lr=self.trainer_config.learning_rate)
+
+        for epoch in range(self.trainer_config.epochs):
+            model.train()
+            running_loss = 0.0
+            for batch_features, batch_targets in train_loader:
+                batch_features = batch_features.to(self.trainer_config.device)
+                batch_targets = batch_targets.to(self.trainer_config.device)
+
+                optimizer.zero_grad()
+                outputs = model(batch_features)
+                loss = criterion(outputs, batch_targets)
+                loss.backward()
+                optimizer.step()
+                running_loss += loss.item() * batch_features.size(0)
+
+            epoch_loss = running_loss / len(train_loader.dataset)
+            print(f"Epoch {epoch + 1}/{self.trainer_config.epochs} - Loss: {epoch_loss:.4f}")
+
+        metrics = self.evaluate(model, test_loader, target_scaler)
+
+        # Persist artifacts
+        self.artifact_paths.model_path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save(model.state_dict(), self.artifact_paths.model_path)
+        joblib.dump(feature_scaler, self.artifact_paths.feature_scaler_path)
+        joblib.dump(target_scaler, self.artifact_paths.target_scaler_path)
+
+        return metrics
+
+    def evaluate(
+        self, model: BidirectionalLSTM, data_loader: DataLoader, target_scaler: StandardScaler
+    ) -> Dict[str, float]:
+        model.eval()
+        predictions = []
+        actuals = []
+        with torch.no_grad():
+            for features, targets in data_loader:
+                features = features.to(self.trainer_config.device)
+                outputs = model(features)
+                predictions.append(outputs.cpu().numpy())
+                actuals.append(targets.numpy())
+
+        pred_array = np.concatenate(predictions, axis=0)
+        actual_array = np.concatenate(actuals, axis=0)
+
+        pred_rescaled = target_scaler.inverse_transform(pred_array)
+        actual_rescaled = target_scaler.inverse_transform(actual_array)
+
+        mse = mean_squared_error(actual_rescaled, pred_rescaled)
+        mae = mean_absolute_error(actual_rescaled, pred_rescaled)
+        mape = (
+            np.mean(np.abs((actual_rescaled - pred_rescaled) / (actual_rescaled + 1e-9)))
+            * 100
+        )
+
+        actual_diff = np.diff(actual_rescaled, axis=1)
+        pred_diff = np.diff(pred_rescaled, axis=1)
+        if actual_diff.size == 0:
+            directional_accuracy = float("nan")
+        else:
+            directional_accuracy = np.mean(np.sign(actual_diff) == np.sign(pred_diff)) * 100
+
+        return {
+            "mse": float(mse),
+            "mae": float(mae),
+            "mape": float(mape),
+            "directional_accuracy": float(directional_accuracy),
+        }
+
+
+__all__ = ["LSTMTrainer", "TrainerConfig", "ArtifactPaths"]


### PR DESCRIPTION
## Summary
- clamp intraday lookbacks to the provider's supported range when building yfinance download requests
- retry downloads with a safe maximum period when the provider rejects the requested range

## Testing
- `python -m compileall .`


------
https://chatgpt.com/codex/tasks/task_e_68e0f80e81b88333969aea56d96a74ad