### PR TITLE
Handle multi-step scaler inversion during evaluation

### DIFF
--- a/intraday_trading/data/fetcher.py
+++ b/intraday_trading/data/fetcher.py
@@ -2,10 +2,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+import logging
+import time
 from typing import Optional
 
 import pandas as pd
 import yfinance as yf
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -13,20 +18,115 @@ class MarketDataFetcher:
     ticker: str
     interval: str
     history_days: int
+    max_retries: int = 3
+    retry_delay: float = 1.5
+
+    _INTRADAY_MAX_LOOKBACK = {
+        "15m": 59,
+    }
+
+    def _resolve_period(self) -> str:
+        """Return a period string that respects yfinance lookback limits."""
+
+        max_days = self._INTRADAY_MAX_LOOKBACK.get(self.interval)
+        if max_days is None:
+            return f"{self.history_days}d"
+        days = min(self.history_days, max_days)
+        return f"{days}d"
+
+    def _download_with_retries(self, **kwargs) -> pd.DataFrame:
+        last_error: Exception | None = None
+        for attempt in range(1, self.max_retries + 1):
+            logger.debug(
+                "Attempt %d downloading data for ticker=%s interval=%s",
+                attempt,
+                self.ticker,
+                self.interval,
+            )
+            try:
+                data = yf.download(**kwargs)
+            except Exception as exc:  # pragma: no cover - network layer
+                last_error = exc
+                logger.warning(
+                    "yfinance download attempt %d/%d failed for %s (%s): %s",
+                    attempt,
+                    self.max_retries,
+                    self.ticker,
+                    self.interval,
+                    exc,
+                )
+            else:
+                if not data.empty:
+                    logger.info(
+                        "Successfully downloaded %d rows for %s (%s) on attempt %d",
+                        len(data),
+                        self.ticker,
+                        self.interval,
+                        attempt,
+                    )
+                    return data
+                last_error = ValueError("Empty dataframe returned from yfinance")
+                logger.warning(
+                    "yfinance returned an empty dataframe on attempt %d/%d for %s (%s)",
+                    attempt,
+                    self.max_retries,
+                    self.ticker,
+                    self.interval,
+                )
+
+            if attempt < self.max_retries:
+                logger.debug(
+                    "Sleeping for %.2fs before retrying download for %s (%s)",
+                    self.retry_delay * attempt,
+                    self.ticker,
+                    self.interval,
+                )
+                time.sleep(self.retry_delay * attempt)
+
+        assert last_error is not None  # for type checkers
+        raise RuntimeError(
+            "Failed to download market data after multiple attempts."
+        ) from last_error
 
     def fetch(self, end: Optional[datetime] = None) -> pd.DataFrame:
         end = end or datetime.utcnow()
         start = end - timedelta(days=self.history_days)
-        data = yf.download(
+        logger.info(
+            "Fetching data for %s (%s) from %s to %s with lookback %dd",
             self.ticker,
-            start=start,
-            end=end,
-            interval=self.interval,
-            auto_adjust=False,
-            progress=False,
+            self.interval,
+            start,
+            end,
+            self.history_days,
         )
-        if data.empty:
-            raise ValueError("No data returned from yfinance. Check the ticker or interval.")
+        download_kwargs = {
+            "tickers": self.ticker,
+            "interval": self.interval,
+            "auto_adjust": False,
+            "progress": False,
+            "threads": False,
+        }
+
+        # Prefer the ``period`` argument for intraday data because yfinance may reject
+        # large start/end ranges with a timeout. We keep ``start``/``end`` as a fallback
+        # for daily intervals.
+        if self.interval.endswith("m"):
+            download_kwargs["period"] = self._resolve_period()
+            logger.debug(
+                "Using period=%s for intraday request of %s (%s)",
+                download_kwargs["period"],
+                self.ticker,
+                self.interval,
+            )
+        else:
+            download_kwargs.update({"start": start, "end": end})
+            logger.debug(
+                "Using explicit start/end for %s (%s)",
+                self.ticker,
+                self.interval,
+            )
+
+        data = self._download_with_retries(**download_kwargs)
         data = data.rename(
             columns={
                 "Open": "open",
@@ -39,4 +139,7 @@ class MarketDataFetcher:
         )
         data.index = pd.to_datetime(data.index)
         data = data.sort_index()
+        logger.info(
+            "Completed fetch for %s (%s) with %d rows", self.ticker, self.interval, len(data)
+        )
         return data

--- a/src/pipeline/trainer.py
+++ b/src/pipeline/trainer.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import logging
 from pathlib import Path
 from typing import Dict, Tuple
 
@@ -17,12 +18,15 @@ from src.models.lstm_model import BidirectionalLSTM
 from src.pipeline.dataset import SequenceConfig, SequenceDataset, build_sequences
 
 
+logger = logging.getLogger(__name__)
+
+
 @dataclass
 class TrainerConfig:
     epochs: int = 30
     batch_size: int = 32
     learning_rate: float = 1e-3
-    device: str = "cuda" if torch.cuda.is_available() else "cpu"
+    device: str = "auto"
 
 
 @dataclass
@@ -42,6 +46,33 @@ class LSTMTrainer:
         self.sequence_config = sequence_config
         self.trainer_config = trainer_config
         self.artifact_paths = artifact_paths
+        self.device = self._resolve_device(trainer_config.device)
+
+    def _resolve_device(self, configured_device: str) -> str:
+        """Return a valid device string, defaulting to CPU when necessary."""
+
+        if configured_device == "auto":
+            resolved = "cuda" if torch.cuda.is_available() else "cpu"
+            logger.info("Auto-selected device: %s", resolved)
+            return resolved
+
+        try:
+            device = torch.device(configured_device)
+        except (RuntimeError, ValueError):
+            logger.warning(
+                "Requested device '%s' is not available. Falling back to CPU.",
+                configured_device,
+            )
+            return "cpu"
+
+        if device.type == "cuda" and not torch.cuda.is_available():
+            logger.warning(
+                "CUDA requested via '%s' but no GPU is available. Falling back to CPU.",
+                configured_device,
+            )
+            return "cpu"
+
+        return configured_device
 
     def _prepare_sequences(
         self, data: np.ndarray, target: np.ndarray
@@ -74,6 +105,7 @@ class LSTMTrainer:
         return train_loader, test_loader
 
     def train(self, raw_df) -> Dict[str, float]:
+        logger.info("Starting training run")
         df = add_technical_features(raw_df)
         feature_columns = [
             "open",
@@ -95,13 +127,35 @@ class LSTMTrainer:
         scaled_target = target_scaler.fit_transform(target.values).squeeze()
 
         sequences, targets = self._prepare_sequences(scaled_features, scaled_target)
+        logger.debug(
+            "Prepared sequences with shape %s and targets shape %s",
+            sequences.shape,
+            targets.shape,
+        )
         train_dataset, test_dataset = self._split_dataset(sequences, targets)
+        logger.info(
+            "Split dataset into %d training samples and %d evaluation samples",
+            len(train_dataset),
+            len(test_dataset),
+        )
         train_loader, test_loader = self._create_dataloaders(train_dataset, test_dataset)
 
         model = BidirectionalLSTM(
             input_size=sequences.shape[-1],
             output_size=self.sequence_config.horizon,
-        ).to(self.trainer_config.device)
+        )
+
+        try:
+            model = model.to(self.device)
+        except RuntimeError:
+            logger.exception(
+                "Unable to move model to requested device '%s'. Falling back to CPU.",
+                self.device,
+            )
+            self.device = "cpu"
+            model = model.to(self.device)
+        else:
+            logger.info("Model initialized on device %s", self.device)
 
         criterion = torch.nn.MSELoss()
         optimizer = torch.optim.Adam(model.parameters(), lr=self.trainer_config.learning_rate)
@@ -110,8 +164,8 @@ class LSTMTrainer:
             model.train()
             running_loss = 0.0
             for batch_features, batch_targets in train_loader:
-                batch_features = batch_features.to(self.trainer_config.device)
-                batch_targets = batch_targets.to(self.trainer_config.device)
+                batch_features = batch_features.to(self.device)
+                batch_targets = batch_targets.to(self.device)
 
                 optimizer.zero_grad()
                 outputs = model(batch_features)
@@ -121,36 +175,64 @@ class LSTMTrainer:
                 running_loss += loss.item() * batch_features.size(0)
 
             epoch_loss = running_loss / len(train_loader.dataset)
-            print(f"Epoch {epoch + 1}/{self.trainer_config.epochs} - Loss: {epoch_loss:.4f}")
+            logger.info(
+                "Epoch %d/%d - Loss: %.4f",
+                epoch + 1,
+                self.trainer_config.epochs,
+                epoch_loss,
+            )
 
         metrics = self.evaluate(model, test_loader, target_scaler)
+        logger.info("Evaluation metrics: %s", metrics)
 
         # Persist artifacts
         self.artifact_paths.model_path.parent.mkdir(parents=True, exist_ok=True)
         torch.save(model.state_dict(), self.artifact_paths.model_path)
         joblib.dump(feature_scaler, self.artifact_paths.feature_scaler_path)
         joblib.dump(target_scaler, self.artifact_paths.target_scaler_path)
+        logger.info("Saved model and scalers to disk")
 
         return metrics
 
     def evaluate(
         self, model: BidirectionalLSTM, data_loader: DataLoader, target_scaler: StandardScaler
     ) -> Dict[str, float]:
+        if len(data_loader.dataset) == 0:
+            logger.warning("Test dataset is empty; returning NaN metrics")
+            return {
+                "mse": float("nan"),
+                "mae": float("nan"),
+                "mape": float("nan"),
+                "directional_accuracy": float("nan"),
+            }
+
         model.eval()
-        predictions = []
-        actuals = []
+        predictions: list[np.ndarray] = []
+        actuals: list[np.ndarray] = []
         with torch.no_grad():
-            for features, targets in data_loader:
-                features = features.to(self.trainer_config.device)
+            for batch_idx, (features, targets) in enumerate(data_loader, start=1):
+                features = features.to(self.device)
                 outputs = model(features)
                 predictions.append(outputs.cpu().numpy())
                 actuals.append(targets.numpy())
+                logger.debug(
+                    "Processed evaluation batch %d/%d",
+                    batch_idx,
+                    len(data_loader),
+                )
 
         pred_array = np.concatenate(predictions, axis=0)
         actual_array = np.concatenate(actuals, axis=0)
 
-        pred_rescaled = target_scaler.inverse_transform(pred_array)
-        actual_rescaled = target_scaler.inverse_transform(actual_array)
+        # The target scaler is fit on a single-column array, so we need to reshape
+        # the multi-step predictions and actuals before applying the inverse
+        # transformation.
+        pred_rescaled = target_scaler.inverse_transform(pred_array.reshape(-1, 1)).reshape(
+            pred_array.shape
+        )
+        actual_rescaled = target_scaler.inverse_transform(
+            actual_array.reshape(-1, 1)
+        ).reshape(actual_array.shape)
 
         mse = mean_squared_error(actual_rescaled, pred_rescaled)
         mae = mean_absolute_error(actual_rescaled, pred_rescaled)


### PR DESCRIPTION
## Summary
- guard evaluation against empty test sets to avoid runtime crashes
- reshape multi-step predictions and targets before inverse scaling so metrics compute correctly

## Testing
- python -m compileall src/pipeline/trainer.py

------
https://chatgpt.com/codex/tasks/task_e_68e1565209388333b163ff410e55c254