### PR TITLE
Handle empty training datasets gracefully

### DIFF
--- a/src/pipeline/trainer.py
+++ b/src/pipeline/trainer.py
@@ -131,6 +131,18 @@ class LSTMTrainer:
         scaled_target = target_scaler.fit_transform(target.values).squeeze()
 
         sequences, targets = self._prepare_sequences(scaled_features, scaled_target)
+        if len(sequences) == 0:
+            required = self.sequence_config.lookback + self.sequence_config.horizon
+            raise ValueError(
+                "Unable to build any training sequences. The dataset only has %d rows "
+                "but requires at least %d rows for lookback=%d and horizon=%d."
+                % (
+                    len(df),
+                    required,
+                    self.sequence_config.lookback,
+                    self.sequence_config.horizon,
+                )
+            )
         _print(
             "DEBUG",
             "Prepared sequences with shape %s and targets shape %s",
@@ -138,6 +150,11 @@ class LSTMTrainer:
             targets.shape,
         )
         train_dataset, test_dataset = self._split_dataset(sequences, targets)
+        if len(train_dataset) == 0:
+            raise ValueError(
+                "Training split is empty. Reduce the lookback window or provide more data "
+                "before training."
+            )
         _print(
             "INFO",
             "Split dataset into %d training samples and %d evaluation samples",


### PR DESCRIPTION
## Summary
- prevent training from proceeding when sequence generation returns no samples
- raise a clear error when the training split is empty so users can adjust their configuration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e203f04e4c8333a36818f0a38b1684