### PR TITLE
Reduce trainer dataset size for faster runs

### DIFF
--- a/src/pipeline/dataset.py
+++ b/src/pipeline/dataset.py
@@ -13,14 +13,29 @@ from torch.utils.data import Dataset
 class SequenceConfig:
     lookback: int = 200
     horizon: int = 10
+    stride: int = 1
+
+    def __post_init__(self) -> None:
+        if self.lookback <= 0:
+            raise ValueError("lookback must be a positive integer")
+        if self.horizon <= 0:
+            raise ValueError("horizon must be a positive integer")
+        if self.stride <= 0:
+            raise ValueError("stride must be a positive integer")
 
 
 class SequenceDataset(Dataset):
     def __init__(self, features: np.ndarray, targets: np.ndarray) -> None:
         if len(features) != len(targets):
             raise ValueError("Features and targets must have the same length")
-        self.features = torch.tensor(features, dtype=torch.float32)
-        self.targets = torch.tensor(targets, dtype=torch.float32)
+        features_tensor = torch.from_numpy(
+            np.asarray(features, dtype=np.float32)
+        ).contiguous()
+        targets_tensor = torch.from_numpy(
+            np.asarray(targets, dtype=np.float32)
+        ).contiguous()
+        self.features = features_tensor
+        self.targets = targets_tensor
 
     def __len__(self) -> int:  # type: ignore[override]
         return len(self.features)
@@ -36,15 +51,55 @@ def build_sequences(
 ) -> tuple[np.ndarray, np.ndarray]:
     lookback = config.lookback
     horizon = config.horizon
-    features = []
-    targets = []
-    for end_idx in range(lookback, len(values) - horizon + 1):
-        start_idx = end_idx - lookback
-        feature_window = values[start_idx:end_idx]
-        target_window = target[end_idx : end_idx + horizon]
-        features.append(feature_window)
-        targets.append(target_window)
-    return np.array(features), np.array(targets)
+    stride = config.stride
+
+    if values.ndim != 2:
+        raise ValueError("values must be a 2D array of shape (timesteps, features)")
+    if target.ndim != 1:
+        raise ValueError("target must be a 1D array with the target series")
+    if len(values) != len(target):
+        raise ValueError("values and target must have the same number of timesteps")
+    if len(values) < lookback + horizon:
+        return np.empty((0, lookback, values.shape[1]), dtype=np.float32), np.empty(
+            (0, horizon), dtype=np.float32
+        )
+
+    # Attempt to use the optimised numpy sliding window implementation. Fallback to
+    # a Python loop if the current numpy version does not expose the helper.
+    feature_windows: np.ndarray
+    target_windows: np.ndarray
+    try:
+        from numpy.lib.stride_tricks import sliding_window_view
+
+        feature_windows = sliding_window_view(values, (lookback, values.shape[1]))
+        feature_windows = feature_windows[:, 0, :, :]
+        target_windows = sliding_window_view(target, horizon)[lookback:]
+    except Exception:  # pragma: no cover - fallback path for old numpy versions
+        features_list = []
+        targets_list = []
+        for end_idx in range(lookback, len(values) - horizon + 1):
+            start_idx = end_idx - lookback
+            features_list.append(values[start_idx:end_idx])
+            targets_list.append(target[end_idx : end_idx + horizon])
+        feature_windows = np.stack(features_list) if features_list else np.empty(
+            (0, lookback, values.shape[1])
+        )
+        target_windows = np.stack(targets_list) if targets_list else np.empty(
+            (0, horizon)
+        )
+
+    total_windows = min(len(feature_windows), len(target_windows))
+    feature_windows = feature_windows[:total_windows]
+    target_windows = target_windows[:total_windows]
+
+    if stride > 1 and total_windows:
+        feature_windows = feature_windows[::stride]
+        target_windows = target_windows[::stride]
+
+    return (
+        np.ascontiguousarray(feature_windows, dtype=np.float32),
+        np.ascontiguousarray(target_windows, dtype=np.float32),
+    )
 
 
 __all__ = ["SequenceDataset", "SequenceConfig", "build_sequences"]

--- a/src/pipeline/trainer.py
+++ b/src/pipeline/trainer.py
@@ -2,9 +2,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import logging
 from pathlib import Path
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
 
 import joblib
 import numpy as np
@@ -20,7 +19,7 @@ from src.pipeline.dataset import SequenceConfig, SequenceDataset, build_sequence
 
 def _print(level: str, message: str, *args) -> None:
     formatted = message % args if args else message
-    print(f"[{level}] {formatted}")
+    print(f"[{level}] {formatted}", flush=True)
 
 
 @dataclass
@@ -29,6 +28,41 @@ class TrainerConfig:
     batch_size: int = 32
     learning_rate: float = 1e-3
     device: str = "auto"
+    hidden_size: int = 64
+    num_layers: int = 2
+    dropout: float = 0.1
+    max_batches_per_epoch: Optional[int] = None
+    early_stopping_patience: Optional[int] = 5
+    improvement_threshold: float = 1e-4
+    max_training_sequences: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if self.epochs <= 0:
+            raise ValueError("epochs must be a positive integer")
+        if self.batch_size <= 0:
+            raise ValueError("batch_size must be a positive integer")
+        if self.learning_rate <= 0:
+            raise ValueError("learning_rate must be positive")
+        if self.hidden_size <= 0:
+            raise ValueError("hidden_size must be a positive integer")
+        if self.num_layers <= 0:
+            raise ValueError("num_layers must be a positive integer")
+        if not 0 <= self.dropout < 1:
+            raise ValueError("dropout must be in the range [0, 1)")
+        if self.max_batches_per_epoch is not None and self.max_batches_per_epoch <= 0:
+            raise ValueError("max_batches_per_epoch must be positive when provided")
+        if (
+            self.early_stopping_patience is not None
+            and self.early_stopping_patience <= 0
+        ):
+            raise ValueError("early_stopping_patience must be positive when provided")
+        if self.improvement_threshold < 0:
+            raise ValueError("improvement_threshold must be non-negative")
+        if (
+            self.max_training_sequences is not None
+            and self.max_training_sequences <= 0
+        ):
+            raise ValueError("max_training_sequences must be positive when provided")
 
 
 @dataclass
@@ -87,24 +121,40 @@ class LSTMTrainer:
         self, features: np.ndarray, targets: np.ndarray, split_ratio: float = 0.8
     ) -> Tuple[SequenceDataset, SequenceDataset]:
         split_index = int(len(features) * split_ratio)
-        train_dataset = SequenceDataset(features[:split_index], targets[:split_index])
+        train_features = features[:split_index]
+        train_targets = targets[:split_index]
+        limit = self.trainer_config.max_training_sequences
+        if limit is not None and len(train_features) > limit:
+            _print(
+                "INFO",
+                "Limiting training set to the most recent %d sequences (of %d total)",
+                limit,
+                len(train_features),
+            )
+            train_features = train_features[-limit:]
+            train_targets = train_targets[-limit:]
+
+        train_dataset = SequenceDataset(train_features, train_targets)
         test_dataset = SequenceDataset(features[split_index:], targets[split_index:])
         return train_dataset, test_dataset
 
     def _create_dataloaders(
         self, train_dataset: SequenceDataset, test_dataset: SequenceDataset
     ) -> Tuple[DataLoader, DataLoader]:
+        pin_memory = self.device == "cuda"
         train_loader = DataLoader(
             train_dataset,
             batch_size=self.trainer_config.batch_size,
             shuffle=True,
             drop_last=False,
+            pin_memory=pin_memory,
         )
         test_loader = DataLoader(
             test_dataset,
             batch_size=self.trainer_config.batch_size,
             shuffle=False,
             drop_last=False,
+            pin_memory=pin_memory,
         )
         return train_loader, test_loader
 
@@ -127,8 +177,10 @@ class LSTMTrainer:
 
         feature_scaler = StandardScaler()
         target_scaler = StandardScaler()
-        scaled_features = feature_scaler.fit_transform(features.values)
-        scaled_target = target_scaler.fit_transform(target.values).squeeze()
+        scaled_features = feature_scaler.fit_transform(features.values).astype(np.float32)
+        scaled_target = (
+            target_scaler.fit_transform(target.values).astype(np.float32).squeeze()
+        )
 
         sequences, targets = self._prepare_sequences(scaled_features, scaled_target)
         _print(
@@ -137,6 +189,18 @@ class LSTMTrainer:
             sequences.shape,
             targets.shape,
         )
+        if len(sequences) == 0:
+            raise ValueError(
+                "Training dataset is empty after sequence generation. "
+                "Provide more historical data or decrease the lookback window."
+            )
+        _print(
+            "INFO",
+            "Generated %d total training sequences using stride %d",
+            len(sequences),
+            self.sequence_config.stride,
+        )
+
         train_dataset, test_dataset = self._split_dataset(sequences, targets)
         _print(
             "INFO",
@@ -149,6 +213,9 @@ class LSTMTrainer:
         model = BidirectionalLSTM(
             input_size=sequences.shape[-1],
             output_size=self.sequence_config.horizon,
+            hidden_size=self.trainer_config.hidden_size,
+            num_layers=self.trainer_config.num_layers,
+            dropout=self.trainer_config.dropout,
         )
 
         try:
@@ -168,10 +235,40 @@ class LSTMTrainer:
         criterion = torch.nn.MSELoss()
         optimizer = torch.optim.Adam(model.parameters(), lr=self.trainer_config.learning_rate)
 
+        total_batches = len(train_loader)
+        configured_batch_cap = self.trainer_config.max_batches_per_epoch
+        effective_batches = (
+            total_batches
+            if configured_batch_cap is None
+            else min(total_batches, configured_batch_cap)
+        )
+        if configured_batch_cap is not None and configured_batch_cap < total_batches:
+            _print(
+                "INFO",
+                "Capping each epoch at %d batches (of %d total)",
+                effective_batches,
+                total_batches,
+            )
+        log_interval = max(1, effective_batches // 5) if effective_batches else 1
+
+        best_loss = float("inf")
+        epochs_without_improvement = 0
+
         for epoch in range(self.trainer_config.epochs):
             model.train()
             running_loss = 0.0
-            for batch_features, batch_targets in train_loader:
+            processed_samples = 0
+            processed_batches = 0
+            _print(
+                "DEBUG",
+                "Epoch %d/%d - starting (%d batches)",
+                epoch + 1,
+                self.trainer_config.epochs,
+                effective_batches,
+            )
+            for batch_idx, (batch_features, batch_targets) in enumerate(
+                train_loader, start=1
+            ):
                 batch_features = batch_features.to(self.device)
                 batch_targets = batch_targets.to(self.device)
 
@@ -181,8 +278,44 @@ class LSTMTrainer:
                 loss.backward()
                 optimizer.step()
                 running_loss += loss.item() * batch_features.size(0)
+                processed_samples += batch_features.size(0)
+                processed_batches += 1
 
-            epoch_loss = running_loss / len(train_loader.dataset)
+                if processed_batches % log_interval == 0 or processed_batches == effective_batches:
+                    _print(
+                        "DEBUG",
+                        "Epoch %d/%d - processed %d/%d batches",
+                        epoch + 1,
+                        self.trainer_config.epochs,
+                        processed_batches,
+                        effective_batches,
+                    )
+
+                if (
+                    configured_batch_cap is not None
+                    and processed_batches >= effective_batches
+                ):
+                    if total_batches > effective_batches:
+                        _print(
+                            "DEBUG",
+                            "Epoch %d/%d - reached configured batch limit (%d/%d)",
+                            epoch + 1,
+                            self.trainer_config.epochs,
+                            processed_batches,
+                            total_batches,
+                        )
+                    break
+
+            if processed_samples == 0:
+                _print(
+                    "WARN",
+                    "Epoch %d/%d - no batches processed; stopping training loop",
+                    epoch + 1,
+                    self.trainer_config.epochs,
+                )
+                break
+
+            epoch_loss = running_loss / processed_samples
             _print(
                 "INFO",
                 "Epoch %d/%d - Loss: %.4f",
@@ -190,6 +323,23 @@ class LSTMTrainer:
                 self.trainer_config.epochs,
                 epoch_loss,
             )
+
+            if epoch_loss + self.trainer_config.improvement_threshold < best_loss:
+                best_loss = epoch_loss
+                epochs_without_improvement = 0
+            else:
+                epochs_without_improvement += 1
+                if (
+                    self.trainer_config.early_stopping_patience is not None
+                    and epochs_without_improvement
+                    >= self.trainer_config.early_stopping_patience
+                ):
+                    _print(
+                        "INFO",
+                        "Early stopping triggered after %d epochs without improvement",
+                        epochs_without_improvement,
+                    )
+                    break
 
         metrics = self.evaluate(model, test_loader, target_scaler)
         _print("INFO", "Evaluation metrics: %s", metrics)


### PR DESCRIPTION
## Summary
- allow TrainerConfig to tune model size and add guards for invalid settings
- wire the TrainerConfig settings into the model and training loop, including optional batch caps
- add loss-based early stopping and accurate averaging to cut epochs short when progress stalls
- vectorize sequence construction with configurable stride support and float32 tensors to reduce preprocessing overhead
- add an optional cap for the most recent training sequences and enable GPU-friendly DataLoader pinning

## Testing
- python - <<'PY'
import pandas as pd
import numpy as np
from pathlib import Path
from src.pipeline.trainer import LSTMTrainer, TrainerConfig, ArtifactPaths
from src.pipeline.dataset import SequenceConfig

idx = pd.date_range('2023-01-01', periods=250, freq='15min')
data = pd.DataFrame({
    'open': np.random.rand(250)*100,
    'high': np.random.rand(250)*100,
    'low': np.random.rand(250)*100,
    'close': np.random.rand(250)*100,
    'volume': np.random.rand(250)*1000,
}, index=idx)

sequence_config = SequenceConfig(lookback=200, horizon=10, stride=2)
trainer_config = TrainerConfig(epochs=5, early_stopping_patience=2, max_training_sequences=128)
paths = ArtifactPaths(Path('artifacts/test_model.pth'), Path('artifacts/test_feature.pkl'), Path('artifacts/test_target.pkl'))

trainer = LSTMTrainer(sequence_config, trainer_config, paths)
metrics = trainer.train(data)
print(metrics)
PY

------
https://chatgpt.com/codex/tasks/task_e_68e203f04e4c8333a36818f0a38b1684